### PR TITLE
allow arrayref of method names to be passed to before, around & after

### DIFF
--- a/lib/Role/Tiny.pm
+++ b/lib/Role/Tiny.pm
@@ -135,6 +135,7 @@ sub _gen_subs {
     (map {;
       my $type = $_;
       $type => sub {
+        unshift @_, @{ +shift } if ref $_[0] eq 'ARRAY';
         push @{$INFO{$target}{modifiers}||=[]}, [ $type => @_ ];
         return;
       };


### PR DESCRIPTION
Hi, I wrote a test, which would fail w/o this patch, but with the patch it passes.

Unfortunately I don't know where exactly to put it in the distribution, and I don't know if you consider it complete. So here is a link to it - please use any way you want: https://gist.github.com/akarelas/4aeea45b2a25d05408d6ccb8aeb692a1