### PR TITLE
Addition of .gitattributes to identify .t files more appropriately for this repository

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.t linguist-language=Perl


### PR DESCRIPTION
I was browsing the repository and observed a minor thing I had just adjusted on on of my repositories. 

linguist used for identifying the languages used in a repository defaults to Raku for .t files, so this is a configuration to let linguist observe .t files as Perl instead of the default of Raku.

In this repository I would guess that 100% Perl would be the correct report.

Take care and stay safe

jonasbn

